### PR TITLE
Fix warning when adding item to the wishlist for the first time

### DIFF
--- a/WishlistModule.php
+++ b/WishlistModule.php
@@ -233,7 +233,7 @@ class WishlistModule extends CatalogController
         if (!Toolkit::isEmpty($arrSession)) {
 
             $arrIds = $arrSession['ids'] ?? [];
-            $arrAmounts = $arrSession['amounts'];
+            $arrAmounts = $arrSession['amounts'] ?? [];
         }
 
         if (\Input::get('wishlist_id') && !in_array(\Input::get('wishlist_id'), $arrIds)) {


### PR DESCRIPTION
Fixes the following warning:

```
ErrorException:
Warning: Undefined array key "amounts"

  at vendor\alnv\catalog-manager-wishlist\WishlistModule.php:236
  at CMWishlist\WishlistModule->getWishlistData()
     (vendor\alnv\catalog-manager-wishlist\WishlistModule.php:160)
  at CMWishlist\WishlistModule->addToWishlist()
     (vendor\alnv\catalog-manager-wishlist\WishlistModule.php:60)
  at CMWishlist\WishlistModule->initialize()
     (vendor\alnv\catalog-manager\library\alnv\CatalogView.php:230)
  at CatalogManager\CatalogView->initialize()
     (vendor\alnv\catalog-manager\library\alnv\Modules\ModuleMasterView.php:88)
  at CatalogManager\ModuleMasterView->compile()
     (vendor\contao\core-bundle\src\Resources\contao\modules\Module.php:214)
  at Contao\Module->generate()
     (vendor\alnv\catalog-manager\library\alnv\Modules\ModuleMasterView.php:46)
  at CatalogManager\ModuleMasterView->generate()
     (vendor\contao\core-bundle\src\Resources\contao\elements\ContentModule.php:98)
  at Contao\ContentModule->generate()
```