### PR TITLE
Use proper responses for wishlist actions

### DIFF
--- a/WishlistModule.php
+++ b/WishlistModule.php
@@ -4,6 +4,8 @@ namespace CMWishlist;
 
 use CatalogManager\CatalogController;
 use CatalogManager\Toolkit;
+use Contao\CoreBundle\Exception\ResponseException;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class WishlistModule extends CatalogController
 {
@@ -192,14 +194,10 @@ class WishlistModule extends CatalogController
 
             $this->renderCatalog($arrCatalog, $this->strTable, $objCatalogView);
 
-            header('Content-Type: application/json');
-
-            echo json_encode([
+            throw new ResponseException(new JsonResponse([
                 'id' => md5(\Input::get('wishlist_id') . $this->strTable),
                 'reload' => $arrCatalog['wishlistForm']
-            ], 512);
-
-            exit;
+            ]));
         }
 
         $strRedirect = preg_replace('/[&,?]wishlist_type=remove_from_wishlist/', '', \Environment::get('request'));


### PR DESCRIPTION
I wanted to customize the response of the wishlist add action but noticed that it completely bypasses the controller pipeline. This PR fixes that by using Contao's `ResponseException` and a proper `JsonResponse`. This way the controller pipeline is upheld.